### PR TITLE
Add missing margin to greeting paragraph

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -40,7 +40,6 @@ body {
 
 #info-symbol:hover + .info-symbol-description {
 	display: block;
-
 }
 
 #stat-symbol, #back-symbol {
@@ -72,6 +71,7 @@ body {
 
 #greeting {
 	float: right;
+	margin-right: 1em;
 }
 
 .grid-container {
@@ -128,6 +128,7 @@ body {
 	align-self: stretch;
 	display: none;
 }
+
 #message {
 	grid-column: 2 / 3;
 	grid-row-start: 4;
@@ -151,6 +152,7 @@ body {
 #current .lexeme {
 	padding: 2em 0;
 }
+
 .lemma {
 	color: #3366cc;
 	font-size: 1.5em;


### PR DESCRIPTION
Also standardize usage of blank lines throughout the `main.css` file.

Before:
<img width="798" alt="Screenshot 2020-03-06 at 11 04 35" src="https://user-images.githubusercontent.com/478237/76078404-83428b00-5f9a-11ea-80e5-296df1c3f06a.png">

After:
<img width="798" alt="Screenshot 2020-03-06 at 11 04 55" src="https://user-images.githubusercontent.com/478237/76078406-8473b800-5f9a-11ea-92e8-6de670bc4dfd.png">
